### PR TITLE
Fix a bug when fetching livephoto

### DIFF
--- a/run.py
+++ b/run.py
@@ -151,7 +151,7 @@ def fetchPhoto(pic, post_id: str, dirname) -> None:
 
     if "type" not in pic:
         return
-    if pic["type"] == "livephotos":
+    if pic["type"] == "livephoto":
         url = pic["videoSrc"]
         if url.split(".")[-1] in ["mov"]:
             filename = f"{dirname}/pic/{post_id}_{pid}.{url.split('.')[-1]}"


### PR DESCRIPTION
Details:
We set UID = 5318459292 for test.
It raises NotImplementedError in fetchPhoto. 
And print(pic) says:
{'pid': '005NVIduly1hxygfn28y7j31sc2dsam5', 'url': 'https://wx3.sinaimg.cn/orj360/005NVIduly1hxygfn28y7j31sc2dsam5.jpg', 'size': 'orj360', 'geo': {'width': 360, 'height': 479, 'croped': False}, 'large': {'size': 'large', 'url': 'https://wx3.sinaimg.cn/large/005NVIduly1hxygfn28y7j31sc2dsam5.jpg', 'geo': {'width': 2048, 'height': 2730, 'croped': False}}, 'videoSrc': 'https://video.weibo.com/media/play?livephoto=https%3A%2F%2Flivephoto.us.sinaimg.cn%2F002RTqXsgx08lsTy45l60f0f0100cxex0k01.mov', 'type': 'livephoto'}
So 'livephotos' should be corrected to 'livephoto'


