### PR TITLE
Fix: Handle corner case while fetching posts

### DIFF
--- a/run.py
+++ b/run.py
@@ -314,25 +314,26 @@ def fetchIncrementalPosts():
         )
 
     # last page case
-    if len(data["cards"]) > 0 and data["cardlistInfo"].get("since_id") is None:
-        for card in data["cards"]:
-            if card["card_type"] == 9:
-                if card["mblog"]["id"] in post_ids:
-                    continue
-                fetchRelatedContent(card["mblog"])
-                posts.append(card["mblog"])
-            elif card["card_type"] == 11 and "card_group" in card:
-                for sub_card in card["card_group"]:
-                    if sub_card["card_type"] == 9:
-                        if sub_card["mblog"]["id"] in post_ids:
-                            continue
-                        fetchRelatedContent(sub_card["mblog"])
-                        posts.append(sub_card["mblog"])
-                    else:
-                        print("[+] Unknown card type", sub_card["card_type"])
-            else:
-                print("[+] Unknown card type", card["card_type"])  
-        print("[+]", len(posts), "posts", posts[-1]["created_at"], "last page!")
+    if len(data["cards"]) == 0:
+        return posts
+    for card in data["cards"]:
+        if card["card_type"] == 9:
+            if card["mblog"]["id"] in post_ids:
+                continue
+            fetchRelatedContent(card["mblog"])
+            posts.append(card["mblog"])
+        elif card["card_type"] == 11 and "card_group" in card:
+            for sub_card in card["card_group"]:
+                if sub_card["card_type"] == 9:
+                    if sub_card["mblog"]["id"] in post_ids:
+                        continue
+                    fetchRelatedContent(sub_card["mblog"])
+                    posts.append(sub_card["mblog"])
+                else:
+                    print("[+] Unknown card type", sub_card["card_type"])
+        else:
+            print("[+] Unknown card type", card["card_type"])  
+    print("[+]", len(posts), "posts", posts[-1]["created_at"], "last page!")
     return posts
 
 
@@ -369,21 +370,22 @@ def fetchPosts():
         )
 
     # last page case:
-    if len(data["cards"]) > 0 and data["cardlistInfo"].get("since_id") is None:
-        for card in data["cards"]:
-            if card["card_type"] == 9:
-                fetchRelatedContent(card["mblog"])
-                posts.append(card["mblog"])
-            elif card["card_type"] == 11 and "card_group" in card:
-                for sub_card in card["card_group"]:
-                    if sub_card["card_type"] == 9:
-                        fetchRelatedContent(sub_card["mblog"])
-                        posts.append(sub_card["mblog"])
-                    else:
-                        print("[+] Unknown card type", sub_card["card_type"])
-            else:
-                print("[+] Unknown card type", card["card_type"])
-        print("[+]", len(posts), "posts", posts[-1]["created_at"], "last page!")
+    if len(data["cards"]) == 0:
+        return posts
+    for card in data["cards"]:
+        if card["card_type"] == 9:
+            fetchRelatedContent(card["mblog"])
+            posts.append(card["mblog"])
+        elif card["card_type"] == 11 and "card_group" in card:
+            for sub_card in card["card_group"]:
+                if sub_card["card_type"] == 9:
+                    fetchRelatedContent(sub_card["mblog"])
+                    posts.append(sub_card["mblog"])
+                else:
+                    print("[+] Unknown card type", sub_card["card_type"])
+        else:
+            print("[+] Unknown card type", card["card_type"])
+    print("[+]", len(posts), "posts", posts[-1]["created_at"], "last page!")
     return posts
 
 

--- a/run.py
+++ b/run.py
@@ -314,6 +314,8 @@ def fetchIncrementalPosts():
         )
 
     # last page case
+    if data["cardlistInfo"].get("since_id"):
+        return posts
     for card in data["cards"]:
         if card["card_type"] == 9:
             if card["mblog"]["id"] in post_ids:

--- a/run.py
+++ b/run.py
@@ -312,6 +312,27 @@ def fetchIncrementalPosts():
             referer=f"https://m.weibo.cn/p/{CID}_-_WEIBO_SECOND_PROFILE_WEIBO",
             cached=True,
         )
+
+    # last page case
+    if len(data["cards"]) > 0 and data["cardlistInfo"].get("since_id") is None:
+        for card in data["cards"]:
+            if card["card_type"] == 9:
+                if card["mblog"]["id"] in post_ids:
+                    continue
+                fetchRelatedContent(card["mblog"])
+                posts.append(card["mblog"])
+            elif card["card_type"] == 11 and "card_group" in card:
+                for sub_card in card["card_group"]:
+                    if sub_card["card_type"] == 9:
+                        if sub_card["mblog"]["id"] in post_ids:
+                            continue
+                        fetchRelatedContent(sub_card["mblog"])
+                        posts.append(sub_card["mblog"])
+                    else:
+                        print("[+] Unknown card type", sub_card["card_type"])
+            else:
+                print("[+] Unknown card type", card["card_type"])  
+        print("[+]", len(posts), "posts", posts[-1]["created_at"], "last page!")
     return posts
 
 
@@ -346,6 +367,23 @@ def fetchPosts():
             referer=f"https://m.weibo.cn/p/{CID}_-_WEIBO_SECOND_PROFILE_WEIBO",
             cached=True,
         )
+
+    # last page case:
+    if len(data["cards"]) > 0 and data["cardlistInfo"].get("since_id") is None:
+        for card in data["cards"]:
+            if card["card_type"] == 9:
+                fetchRelatedContent(card["mblog"])
+                posts.append(card["mblog"])
+            elif card["card_type"] == 11 and "card_group" in card:
+                for sub_card in card["card_group"]:
+                    if sub_card["card_type"] == 9:
+                        fetchRelatedContent(sub_card["mblog"])
+                        posts.append(sub_card["mblog"])
+                    else:
+                        print("[+] Unknown card type", sub_card["card_type"])
+            else:
+                print("[+] Unknown card type", card["card_type"])
+        print("[+]", len(posts), "posts", posts[-1]["created_at"], "last page!")
     return posts
 
 

--- a/run.py
+++ b/run.py
@@ -314,8 +314,6 @@ def fetchIncrementalPosts():
         )
 
     # last page case
-    if len(data["cards"]) == 0:
-        return posts
     for card in data["cards"]:
         if card["card_type"] == 9:
             if card["mblog"]["id"] in post_ids:
@@ -373,8 +371,6 @@ def fetchPosts():
         )
 
     # last page case:
-    if len(data["cards"]) == 0:
-        return posts
     for card in data["cards"]:
         if card["card_type"] == 9:
             fetchRelatedContent(card["mblog"])

--- a/run.py
+++ b/run.py
@@ -333,6 +333,9 @@ def fetchIncrementalPosts():
                     print("[+] Unknown card type", sub_card["card_type"])
         else:
             print("[+] Unknown card type", card["card_type"])  
+    if not posts:
+        print("[+]", "No posts found!")
+        return posts
     print("[+]", len(posts), "posts", posts[-1]["created_at"], "last page!")
     return posts
 
@@ -385,6 +388,9 @@ def fetchPosts():
                     print("[+] Unknown card type", sub_card["card_type"])
         else:
             print("[+] Unknown card type", card["card_type"])
+    if not posts:
+        print("[+]", "No posts found!")
+        return posts
     print("[+]", len(posts), "posts", posts[-1]["created_at"], "last page!")
     return posts
 


### PR DESCRIPTION
We handle the corner case when the while loop in fetchPosts()/fetchIncrementalPosts() reaches the last page.

Especially, when there is only one page, "since_id" in data["cardlistInfo"] is False and we won't enter the while loop. So fetchPosts() returns an empty list, which is not we want.

Here are some test cases when threre is only one page to fetch and data["cardlistInfo"].get("since_id") is None:
UID = 1765893783, 7422086009